### PR TITLE
feat: add compose NavHost

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -48,22 +48,26 @@ android {
 }
 
 dependencies {
-
     implementation 'androidx.core:core-ktx:1.7.0'
     implementation "androidx.compose.ui:ui:$compose_version"
     implementation "androidx.compose.material:material:$compose_version"
+    implementation "androidx.compose.material3:material3:$material_version"
     implementation "androidx.compose.ui:ui-tooling-preview:$compose_version"
     implementation 'androidx.lifecycle:lifecycle-runtime-ktx:2.4.1'
     implementation 'androidx.activity:activity-compose:1.4.0'
+    implementation "androidx.navigation:navigation-compose:$nav_version"
     implementation "com.google.accompanist:accompanist-systemuicontroller:0.24.3-alpha"
-    implementation "androidx.compose.material3:material3:$material_version"
     implementation "com.jakewharton.timber:timber:5.0.1"
+
+    // Retrofit and moshi for API calls
     implementation "com.squareup.retrofit2:retrofit:2.9.0"
     implementation "com.squareup.retrofit2:converter-moshi:2.9.0"
     implementation "com.squareup.moshi:moshi-kotlin:1.11.0"
     kapt("com.squareup.moshi:moshi-kotlin-codegen:1.13.0")
 
+    // Dependency injection
     implementation "com.google.dagger:hilt-android:2.38.1"
+    implementation "androidx.hilt:hilt-navigation-compose:1.0.0"
     implementation "androidx.lifecycle:lifecycle-viewmodel-compose:2.5.0-alpha04"
     kapt "com.google.dagger:hilt-compiler:2.38.1"
 

--- a/app/src/main/java/com/washuTechnologies/merced/MainActivity.kt
+++ b/app/src/main/java/com/washuTechnologies/merced/MainActivity.kt
@@ -3,8 +3,7 @@ package com.washuTechnologies.merced
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
-import com.washuTechnologies.merced.ui.launchlist.RocketLaunchListScreen
-import com.washuTechnologies.merced.ui.theme.MercedTheme
+import com.washuTechnologies.merced.ui.MercedApp
 import dagger.hilt.android.AndroidEntryPoint
 
 @AndroidEntryPoint
@@ -12,9 +11,7 @@ class MainActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContent {
-            MercedTheme {
-                RocketLaunchListScreen()
-            }
+            MercedApp()
         }
     }
 }

--- a/app/src/main/java/com/washuTechnologies/merced/ui/MercedApp.kt
+++ b/app/src/main/java/com/washuTechnologies/merced/ui/MercedApp.kt
@@ -1,0 +1,15 @@
+package com.washuTechnologies.merced.ui
+
+import androidx.compose.runtime.Composable
+import com.washuTechnologies.merced.ui.components.MercedScaffold
+import com.washuTechnologies.merced.ui.navigation.MercedNavGraph
+import com.washuTechnologies.merced.ui.theme.MercedTheme
+
+@Composable
+fun MercedApp() {
+    MercedTheme {
+        MercedScaffold {
+            MercedNavGraph()
+        }
+    }
+}

--- a/app/src/main/java/com/washuTechnologies/merced/ui/launchlist/LaunchListViewModel.kt
+++ b/app/src/main/java/com/washuTechnologies/merced/ui/launchlist/LaunchListViewModel.kt
@@ -21,7 +21,6 @@ import javax.inject.Inject
 class LaunchListViewModel @Inject constructor(
     launchRepository: RocketLaunchRepository,
     @IoDispatcher dispatcher: CoroutineDispatcher
-
 ) : ViewModel() {
     private val _uiState = MutableStateFlow<LaunchListUiState>(LaunchListUiState.Loading)
 

--- a/app/src/main/java/com/washuTechnologies/merced/ui/launchlist/RocketLaunchListScreen.kt
+++ b/app/src/main/java/com/washuTechnologies/merced/ui/launchlist/RocketLaunchListScreen.kt
@@ -22,9 +22,8 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
-import androidx.lifecycle.viewmodel.compose.viewModel
+import androidx.hilt.navigation.compose.hiltViewModel
 import com.washuTechnologies.merced.api.launches.RocketLaunch
-import com.washuTechnologies.merced.ui.components.MercedScaffold
 import com.washuTechnologies.merced.ui.theme.MercedTheme
 import timber.log.Timber
 
@@ -32,28 +31,26 @@ import timber.log.Timber
  * Display a list of rocket launches.
  */
 @Composable
-fun RocketLaunchListScreen(viewModel: LaunchListViewModel = viewModel()) {
+fun RocketLaunchListScreen(viewModel: LaunchListViewModel = hiltViewModel()) {
     val list = viewModel.uiState.collectAsState()
     RocketLaunchListScreen(launchList = list.value)
 }
 
 @Composable
 fun RocketLaunchListScreen(launchList: LaunchListUiState) {
-    MercedScaffold {
-        Column(
-            modifier = Modifier.fillMaxSize()
-        ) {
-            Timber.d("RocketLaunchList collect $launchList")
-            when (launchList) {
-                is LaunchListUiState.Success -> {
-                    LaunchList(launchList = launchList.launchList)
-                }
-                is LaunchListUiState.Error -> {
-                    Text(text = "Error")
-                }
-                is LaunchListUiState.Loading -> {
-                    Text(text = "Loading")
-                }
+    Column(
+        modifier = Modifier.fillMaxSize()
+    ) {
+        Timber.d("RocketLaunchList collect $launchList")
+        when (launchList) {
+            is LaunchListUiState.Success -> {
+                LaunchList(launchList = launchList.launchList)
+            }
+            is LaunchListUiState.Error -> {
+                Text(text = "Error")
+            }
+            is LaunchListUiState.Loading -> {
+                Text(text = "Loading")
             }
         }
     }

--- a/app/src/main/java/com/washuTechnologies/merced/ui/navigation/NavHost.kt
+++ b/app/src/main/java/com/washuTechnologies/merced/ui/navigation/NavHost.kt
@@ -1,0 +1,26 @@
+package com.washuTechnologies.merced.ui.navigation
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.navigation.NavHostController
+import androidx.navigation.compose.NavHost
+import androidx.navigation.compose.composable
+import androidx.navigation.compose.rememberNavController
+import com.washuTechnologies.merced.ui.launchlist.RocketLaunchListScreen
+
+@Composable
+fun MercedNavGraph(
+    modifier: Modifier = Modifier,
+    navController: NavHostController = rememberNavController(),
+    startDestination: String = Screen.LaunchList.route
+) {
+    NavHost(
+        navController = navController,
+        startDestination = startDestination,
+        modifier = modifier
+    ) {
+        composable(Screen.LaunchList.route) {
+            RocketLaunchListScreen()
+        }
+    }
+}

--- a/app/src/main/java/com/washuTechnologies/merced/ui/navigation/Screens.kt
+++ b/app/src/main/java/com/washuTechnologies/merced/ui/navigation/Screens.kt
@@ -1,0 +1,12 @@
+package com.washuTechnologies.merced.ui.navigation
+
+/**
+ * Model the various screens throughout the app.
+ */
+sealed class Screen(val route: String) {
+
+    /**
+     * The list of rocket launches.
+     */
+    object LaunchList : Screen("launchList")
+}

--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,6 @@
 buildscript {
     ext {
+        nav_version = "2.4.1"
         compose_version = '1.1.1'
         material_version = '1.0.0-alpha07'
         mockk_version = '1.12.3'

--- a/config/detekt.yml
+++ b/config/detekt.yml
@@ -115,9 +115,7 @@ naming:
       - '**/jvmTest/**'
       - '**/jsTest/**'
       - '**/iosTest/**'
-      - '**/ui/theme/**'
-      - '**/ui/**/*Screen.kt'
-      - '**/ui/**/MercedScaffold.kt'
+    ignoreAnnotated: ['Composable']
   TopLevelPropertyNaming:
     constantPattern: '[a-z][_A-Za-z0-9]*|[A-Z][_A-Z0-9]*'
   InvalidPackageDeclaration:


### PR DESCRIPTION
Introduce a compose navigation graph to the app. Uses a sealed class to model the app screens separate to the graph itself following the example in the compose documentation. The launch list has been set as the default destination.

The detekt configuration for the function naming rule has been updated to ignore all functions with marked with @Composable. As this is more reliable and maintainable than updating the list of excluded files.