### PR TITLE
feat: add placeholder launch detail screen

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -62,6 +62,7 @@ dependencies {
     // Retrofit and moshi for API calls
     implementation "com.squareup.retrofit2:retrofit:2.9.0"
     implementation "com.squareup.retrofit2:converter-moshi:2.9.0"
+    implementation 'com.squareup.okhttp3:logging-interceptor:4.9.1'
     implementation "com.squareup.moshi:moshi-kotlin:1.11.0"
     kapt("com.squareup.moshi:moshi-kotlin-codegen:1.13.0")
 

--- a/app/src/main/java/com/washuTechnologies/merced/api/launches/LaunchesApi.kt
+++ b/app/src/main/java/com/washuTechnologies/merced/api/launches/LaunchesApi.kt
@@ -1,10 +1,13 @@
 package com.washuTechnologies.merced.api.launches
 
 import com.squareup.moshi.Moshi
+import com.washuTechnologies.merced.BuildConfig
 import okhttp3.OkHttpClient
+import okhttp3.logging.HttpLoggingInterceptor
 import retrofit2.Retrofit
 import retrofit2.converter.moshi.MoshiConverterFactory
 import retrofit2.http.GET
+import retrofit2.http.Path
 import java.util.concurrent.Executors
 
 /**
@@ -18,18 +21,32 @@ interface LaunchesApi {
     @GET("launches")
     suspend fun getRocketLaunchList(): Array<RocketLaunch>
 
+    /**
+     * Retrieve information about a single rocket launch using it's id.
+     */
+    @GET("launches/{id}")
+    suspend fun getRocketLaunch(@Path("id") id: String): RocketLaunch
+
+
     companion object {
+        private val loggingInterceptor: HttpLoggingInterceptor
+            get() {
+                val interceptor = HttpLoggingInterceptor()
+                return interceptor.setLevel(HttpLoggingInterceptor.Level.BASIC)
+            }
 
         /**
          * Factory method to create a Retrofit API.
          */
         fun create(): LaunchesApi {
             val client = OkHttpClient.Builder()
-                .build()
+            if (BuildConfig.DEBUG) {
+                client.addInterceptor(loggingInterceptor)
+            }
 
             return Retrofit.Builder()
                 .baseUrl("https://api.spacexdata.com/v4/")
-                .client(client)
+                .client(client.build())
                 .callbackExecutor(Executors.newSingleThreadExecutor())
                 .addConverterFactory(
                     MoshiConverterFactory.create(

--- a/app/src/main/java/com/washuTechnologies/merced/api/launches/RocketLaunch.kt
+++ b/app/src/main/java/com/washuTechnologies/merced/api/launches/RocketLaunch.kt
@@ -8,6 +8,8 @@ import com.squareup.moshi.JsonClass
  */
 @JsonClass(generateAdapter = true)
 data class RocketLaunch(
+    @Json(name = "id")
+    val id: String,
     @Json(name = "flight_number")
     val flightNumber: Int,
     @Json(name = "name")

--- a/app/src/main/java/com/washuTechnologies/merced/api/launches/RocketLaunchRepository.kt
+++ b/app/src/main/java/com/washuTechnologies/merced/api/launches/RocketLaunchRepository.kt
@@ -5,6 +5,7 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.retry
+import timber.log.Timber
 import javax.inject.Inject
 import javax.inject.Singleton
 
@@ -22,8 +23,23 @@ class RocketLaunchRepository @Inject constructor(private val launchesApi: Launch
     fun getLaunchList(): Flow<Result<Array<RocketLaunch>>> = flow {
         emit(Result.Loading)
         val list = launchesApi.getRocketLaunchList()
+        Timber.d("List of ${list.size} rocket launches returned")
         emit(Result.Success(list))
-    }.catch {
+    }.catch { exception ->
+        Timber.e(exception, "Error requesting list of rocket launches")
+        emit(Result.Error)
+    }.retry(MAX_RETRY)
+
+    /**
+     * Retrieve information about a specific launch using its flight number.
+     */
+    fun getRocketLaunch(flightNumber: String): Flow<Result<RocketLaunch>> = flow {
+        emit(Result.Loading)
+        val launch = launchesApi.getRocketLaunch(flightNumber)
+        Timber.d("Retrieved flight ${launch.name}, $flightNumber")
+        emit(Result.Success(launch))
+    }.catch { exception ->
+        Timber.e(exception, "Error requesting rocket launch with flight number $flightNumber")
         emit(Result.Error)
     }.retry(MAX_RETRY)
 }

--- a/app/src/main/java/com/washuTechnologies/merced/api/launches/RocketLaunchRepository.kt
+++ b/app/src/main/java/com/washuTechnologies/merced/api/launches/RocketLaunchRepository.kt
@@ -33,13 +33,13 @@ class RocketLaunchRepository @Inject constructor(private val launchesApi: Launch
     /**
      * Retrieve information about a specific launch using its flight number.
      */
-    fun getRocketLaunch(flightNumber: String): Flow<Result<RocketLaunch>> = flow {
+    fun getRocketLaunch(launchId: String): Flow<Result<RocketLaunch>> = flow {
         emit(Result.Loading)
-        val launch = launchesApi.getRocketLaunch(flightNumber)
-        Timber.d("Retrieved flight ${launch.name}, $flightNumber")
+        val launch = launchesApi.getRocketLaunch(launchId)
+        Timber.d("Retrieved flight ${launch.name}, $launchId")
         emit(Result.Success(launch))
     }.catch { exception ->
-        Timber.e(exception, "Error requesting rocket launch with flight number $flightNumber")
+        Timber.e(exception, "Error requesting rocket launch with flight number $launchId")
         emit(Result.Error)
     }.retry(MAX_RETRY)
 }

--- a/app/src/main/java/com/washuTechnologies/merced/ui/launchdetail/RocketLaunchDetailScreen.kt
+++ b/app/src/main/java/com/washuTechnologies/merced/ui/launchdetail/RocketLaunchDetailScreen.kt
@@ -1,0 +1,71 @@
+package com.washuTechnologies.merced.ui.launchdetail
+
+import android.content.res.Configuration.UI_MODE_NIGHT_YES
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.material.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.hilt.navigation.compose.hiltViewModel
+import com.washuTechnologies.merced.R
+import com.washuTechnologies.merced.ui.theme.MercedTheme
+import com.washuTechnologies.merced.util.PreviewData
+
+/**
+ * Display a list of rocket launches.
+ */
+@Composable
+fun RocketLaunchDetailScreen(
+    viewModel: RocketLaunchViewModel = hiltViewModel()
+) {
+    val launchState = viewModel.uiState.collectAsState()
+    RocketLaunchDetailScreen(rocketLaunchState = launchState.value)
+}
+
+@Composable
+fun RocketLaunchDetailScreen(
+    rocketLaunchState: RocketLaunchUiState
+) {
+    Column(
+        modifier = Modifier.fillMaxSize()
+    ) {
+        when (rocketLaunchState) {
+            is RocketLaunchUiState.Success -> {
+                Text(text = "$rocketLaunchState")
+            }
+            is RocketLaunchUiState.Error -> {
+                Text(text = stringResource(id = R.string.error_generic_message))
+            }
+            is RocketLaunchUiState.Loading -> {
+                Text(text = stringResource(id = R.string.loading_generic_message))
+            }
+            RocketLaunchUiState.InvalidId -> {
+                Text(text = stringResource(id = R.string.invalid_launch_id_message))
+            }
+        }
+    }
+}
+
+@Preview(
+    name = "Dark theme Launch List",
+    showSystemUi = true,
+    uiMode = UI_MODE_NIGHT_YES
+)
+@Preview(
+    name = "Light theme Launch List in German",
+    locale = "DE",
+    fontScale = 2f
+)
+@Composable
+private fun Preview() {
+    MercedTheme {
+        RocketLaunchDetailScreen(
+            rocketLaunchState = RocketLaunchUiState.Success(
+                PreviewData.rocketLaunch,
+            )
+        )
+    }
+}

--- a/app/src/main/java/com/washuTechnologies/merced/ui/launchdetail/RocketLaunchViewModel.kt
+++ b/app/src/main/java/com/washuTechnologies/merced/ui/launchdetail/RocketLaunchViewModel.kt
@@ -22,8 +22,8 @@ import javax.inject.Inject
 @HiltViewModel
 class RocketLaunchViewModel @Inject constructor(
     launchRepository: RocketLaunchRepository,
-    @IoDispatcher dispatcher: CoroutineDispatcher,
-    savedStateHandle: SavedStateHandle
+    savedStateHandle: SavedStateHandle,
+    @IoDispatcher dispatcher: CoroutineDispatcher
 ) : ViewModel() {
     private val flightNumber: String = savedStateHandle.get<String>(
         Screen.LaunchDetail.launchIdKey

--- a/app/src/main/java/com/washuTechnologies/merced/ui/launchdetail/RocketLaunchViewModel.kt
+++ b/app/src/main/java/com/washuTechnologies/merced/ui/launchdetail/RocketLaunchViewModel.kt
@@ -25,7 +25,7 @@ class RocketLaunchViewModel @Inject constructor(
     savedStateHandle: SavedStateHandle,
     @IoDispatcher dispatcher: CoroutineDispatcher
 ) : ViewModel() {
-    private val flightNumber: String = savedStateHandle.get<String>(
+    private val launchId: String = savedStateHandle.get<String>(
         Screen.LaunchDetail.launchIdKey
     ) ?: ""
 
@@ -39,12 +39,12 @@ class RocketLaunchViewModel @Inject constructor(
 
     init {
         viewModelScope.launch(dispatcher) {
-            if (flightNumber.isBlank()) {
+            if (launchId.isBlank()) {
                 Timber.e("Unable to show launch info for a blank id")
                 _uiState.emit(RocketLaunchUiState.InvalidId)
                 return@launch
             }
-            launchRepository.getRocketLaunch(flightNumber).collect {
+            launchRepository.getRocketLaunch(launchId).collect {
                 when (it) {
                     is Result.Success -> _uiState.emit(RocketLaunchUiState.Success(it.result))
                     is Result.Loading -> _uiState.emit(RocketLaunchUiState.Loading)

--- a/app/src/main/java/com/washuTechnologies/merced/ui/launchdetail/RocketLaunchViewModel.kt
+++ b/app/src/main/java/com/washuTechnologies/merced/ui/launchdetail/RocketLaunchViewModel.kt
@@ -1,0 +1,82 @@
+package com.washuTechnologies.merced.ui.launchdetail
+
+import androidx.lifecycle.SavedStateHandle
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.washuTechnologies.merced.api.Result
+import com.washuTechnologies.merced.api.launches.RocketLaunch
+import com.washuTechnologies.merced.api.launches.RocketLaunchRepository
+import com.washuTechnologies.merced.di.IoDispatcher
+import com.washuTechnologies.merced.ui.navigation.Screen
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.launch
+import timber.log.Timber
+import javax.inject.Inject
+
+/**
+ * View model for the list of rocket launches
+ */
+@HiltViewModel
+class RocketLaunchViewModel @Inject constructor(
+    launchRepository: RocketLaunchRepository,
+    @IoDispatcher dispatcher: CoroutineDispatcher,
+    savedStateHandle: SavedStateHandle
+) : ViewModel() {
+    private val flightNumber: String = savedStateHandle.get<String>(
+        Screen.LaunchDetail.launchIdKey
+    ) ?: ""
+
+    private val _uiState = MutableStateFlow<RocketLaunchUiState>(RocketLaunchUiState.Loading)
+
+    /**
+     * Exposes the current state of the launch list screen.
+     */
+    val uiState: StateFlow<RocketLaunchUiState>
+        get() = _uiState
+
+    init {
+        viewModelScope.launch(dispatcher) {
+            if (flightNumber.isBlank()) {
+                Timber.e("Unable to show launch info for a blank id")
+                _uiState.emit(RocketLaunchUiState.InvalidId)
+                return@launch
+            }
+            launchRepository.getRocketLaunch(flightNumber).collect {
+                when (it) {
+                    is Result.Success -> _uiState.emit(RocketLaunchUiState.Success(it.result))
+                    is Result.Loading -> _uiState.emit(RocketLaunchUiState.Loading)
+                    is Result.Error -> _uiState.emit(RocketLaunchUiState.Error)
+                }
+            }
+        }
+    }
+}
+
+/**
+ * The various UI states of the rocket launch list screen.
+ */
+sealed class RocketLaunchUiState {
+
+    /**
+     * Indicates the rocket launch details could be successfully loaded.
+     */
+    data class Success(val launch: RocketLaunch) : RocketLaunchUiState()
+
+    /**
+     * Indicates an error occurred obtaining rocket launch information.
+     */
+    object Error : RocketLaunchUiState()
+
+    /**
+     * Indicates the passed id is not in the correct format.
+     */
+    object InvalidId : RocketLaunchUiState()
+
+    /**
+     * Indicates the detail screen is still loading.
+     */
+    object Loading : RocketLaunchUiState()
+}

--- a/app/src/main/java/com/washuTechnologies/merced/ui/launchlist/RocketLaunchListScreen.kt
+++ b/app/src/main/java/com/washuTechnologies/merced/ui/launchlist/RocketLaunchListScreen.kt
@@ -2,6 +2,7 @@ package com.washuTechnologies.merced.ui.launchlist
 
 import android.content.res.Configuration.UI_MODE_NIGHT_YES
 import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -20,47 +21,65 @@ import androidx.compose.runtime.collectAsState
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
+import com.washuTechnologies.merced.R
 import com.washuTechnologies.merced.api.launches.RocketLaunch
 import com.washuTechnologies.merced.ui.theme.MercedTheme
+import com.washuTechnologies.merced.util.PreviewData
 import timber.log.Timber
 
 /**
  * Display a list of rocket launches.
  */
 @Composable
-fun RocketLaunchListScreen(viewModel: LaunchListViewModel = hiltViewModel()) {
+fun RocketLaunchListScreen(
+    viewModel: LaunchListViewModel = hiltViewModel(),
+    onLaunchSelected: (String) -> Unit
+) {
     val list = viewModel.uiState.collectAsState()
-    RocketLaunchListScreen(launchList = list.value)
+    RocketLaunchListScreen(launchList = list.value, onLaunchSelected = onLaunchSelected)
 }
 
 @Composable
-fun RocketLaunchListScreen(launchList: LaunchListUiState) {
+fun RocketLaunchListScreen(
+    launchList: LaunchListUiState,
+    onLaunchSelected: (String) -> Unit = {}
+) {
     Column(
         modifier = Modifier.fillMaxSize()
     ) {
-        Timber.d("RocketLaunchList collect $launchList")
         when (launchList) {
             is LaunchListUiState.Success -> {
-                LaunchList(launchList = launchList.launchList)
+                LaunchList(launchList = launchList.launchList, onLaunchSelected)
             }
             is LaunchListUiState.Error -> {
-                Text(text = "Error")
+                Text(text = stringResource(id = R.string.error_generic_message))
             }
             is LaunchListUiState.Loading -> {
-                Text(text = "Loading")
+                Text(text = stringResource(id = R.string.loading_generic_message))
             }
         }
     }
 }
 
 @Composable
-private fun LaunchList(launchList: Array<RocketLaunch>) {
+private fun LaunchList(
+    launchList: Array<RocketLaunch>,
+    onLaunchSelected: (String) -> Unit
+) {
     LazyColumn {
         items(items = launchList) { item ->
-            LaunchSummary(launch = item)
+            LaunchSummary(
+                modifier = Modifier.clickable {
+                    val selectedId = item.id
+                    Timber.d("Flight id $selectedId selected")
+                    onLaunchSelected(selectedId)
+                },
+                launch = item
+            )
         }
     }
 }
@@ -112,13 +131,7 @@ private fun LaunchNumber(modifier: Modifier = Modifier, flightNumber: Int) {
 private fun Preview() {
     MercedTheme {
         RocketLaunchListScreen(
-            launchList = LaunchListUiState.Success(
-                arrayOf(
-                    RocketLaunch(1, "FalconSat", "2006-03-24T22:30:00.000Z"),
-                    RocketLaunch(2, "DemoSat", "2007-03-21T01:10:00.000Z"),
-                    RocketLaunch(3, "Trailblazer", "2008-09-28T23:15:00.000Z")
-                )
-            )
+            launchList = LaunchListUiState.Success(PreviewData.launchList)
         )
     }
 }

--- a/app/src/main/java/com/washuTechnologies/merced/ui/navigation/NavHost.kt
+++ b/app/src/main/java/com/washuTechnologies/merced/ui/navigation/NavHost.kt
@@ -1,6 +1,5 @@
 package com.washuTechnologies.merced.ui.navigation
 
-import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.navigation.NavHostController
@@ -9,6 +8,7 @@ import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.navigation.compose.rememberNavController
 import androidx.navigation.navArgument
+import com.washuTechnologies.merced.ui.launchdetail.RocketLaunchDetailScreen
 import com.washuTechnologies.merced.ui.launchlist.RocketLaunchListScreen
 
 @Composable
@@ -33,7 +33,7 @@ fun MercedNavGraph(
                 type = NavType.StringType
             })
         ) {
-            Text("Rocket flight number is ${it.arguments?.getInt(Screen.LaunchDetail.launchDetailKey)}")
+            RocketLaunchDetailScreen()
         }
     }
 }

--- a/app/src/main/java/com/washuTechnologies/merced/ui/navigation/NavHost.kt
+++ b/app/src/main/java/com/washuTechnologies/merced/ui/navigation/NavHost.kt
@@ -1,11 +1,14 @@
 package com.washuTechnologies.merced.ui.navigation
 
+import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.navigation.NavHostController
+import androidx.navigation.NavType
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.navigation.compose.rememberNavController
+import androidx.navigation.navArgument
 import com.washuTechnologies.merced.ui.launchlist.RocketLaunchListScreen
 
 @Composable
@@ -20,7 +23,17 @@ fun MercedNavGraph(
         modifier = modifier
     ) {
         composable(Screen.LaunchList.route) {
-            RocketLaunchListScreen()
+            RocketLaunchListScreen() {
+                navController.navigate(Screen.LaunchDetail.create(it))
+            }
+        }
+        composable(
+            route = Screen.LaunchDetail.route,
+            arguments = listOf(navArgument(Screen.LaunchDetail.launchIdKey) {
+                type = NavType.StringType
+            })
+        ) {
+            Text("Rocket flight number is ${it.arguments?.getInt(Screen.LaunchDetail.launchDetailKey)}")
         }
     }
 }

--- a/app/src/main/java/com/washuTechnologies/merced/ui/navigation/Screens.kt
+++ b/app/src/main/java/com/washuTechnologies/merced/ui/navigation/Screens.kt
@@ -4,9 +4,23 @@ package com.washuTechnologies.merced.ui.navigation
  * Model the various screens throughout the app.
  */
 sealed class Screen(val route: String) {
-
     /**
-     * The list of rocket launches.
+     * A screen displaying a list of rocket launches.
      */
     object LaunchList : Screen("launchList")
+
+    /**
+     * A screen displaying detailed information about a rocket launch.
+     */
+    object LaunchDetail : Screen("launchDetail/{id}") {
+        /**
+         * Navigation argument for the flight number.
+         */
+        const val launchIdKey = "id"
+
+        /**
+         * Create the route string for use with the compose navigation.
+         */
+        fun create(launchId: String) = "launchDetail/$launchId"
+    }
 }

--- a/app/src/main/java/com/washuTechnologies/merced/util/PreviewData.kt
+++ b/app/src/main/java/com/washuTechnologies/merced/util/PreviewData.kt
@@ -1,16 +1,22 @@
-package com.washuTechnologies.merced.ui.launchlist
+package com.washuTechnologies.merced.util
 
 import com.washuTechnologies.merced.api.launches.RocketLaunch
 
 /**
- * Sample rocket launch data for use in testing.
+ * Mock data for use in compose preview annotations.
  */
-object LaunchSampleData {
+object PreviewData {
 
     /**
-     * Sample list of rocket launches.
+     * Information about a single rocket launch.
      */
-    val sampleLaunches: Array<RocketLaunch>
+    val rocketLaunch: RocketLaunch
+        get() = launchList.first()
+
+    /**
+     * A list of rocket launches.
+     */
+    val launchList: Array<RocketLaunch>
         get() = arrayOf(
             RocketLaunch(
                 id = "5eb87cd9ffd86e000604b32a",

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,3 +1,6 @@
 <resources>
     <string name="app_name">Merced</string>
+    <string name="error_generic_message">Error</string>
+    <string name="loading_generic_message">Loading</string>
+    <string name="invalid_launch_id_message">Loading</string>
 </resources>

--- a/app/src/test/java/com/washuTechnologies/merced/intergrationtest/ui/launchdetail/RocketLaunchDetailViewModelIntegrationTest.kt
+++ b/app/src/test/java/com/washuTechnologies/merced/intergrationtest/ui/launchdetail/RocketLaunchDetailViewModelIntegrationTest.kt
@@ -1,0 +1,90 @@
+package com.washuTechnologies.merced.intergrationtest.ui.launchdetail
+
+import android.accounts.NetworkErrorException
+import androidx.lifecycle.SavedStateHandle
+import com.washuTechnologies.merced.api.launches.LaunchesApi
+import com.washuTechnologies.merced.api.launches.RocketLaunchRepository
+import com.washuTechnologies.merced.ui.launchdetail.RocketLaunchUiState
+import com.washuTechnologies.merced.ui.launchdetail.RocketLaunchViewModel
+import com.washuTechnologies.merced.util.LaunchSampleData
+import com.washuTechnologies.merced.util.MockHelper.mockApi
+import io.mockk.coEvery
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.last
+import kotlinx.coroutines.flow.take
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+@ExperimentalCoroutinesApi
+class RocketLaunchDetailViewModelIntegrationTest {
+
+    @Test
+    fun `when a launch list is requested then loading is first returned`() = runTest() {
+        val expectedLaunch = LaunchSampleData.rocketLaunch
+        val mockApi = mockApi(expectedLaunch)
+        val mockSavedState = mockk<SavedStateHandle> {
+            every { get<String>(any()) } returns expectedLaunch.id
+        }
+
+        RocketLaunchViewModel(
+            RocketLaunchRepository(mockApi),
+            mockSavedState,
+            StandardTestDispatcher(testScheduler)
+        ).run {
+            val actual = uiState.first()
+            Assert.assertTrue(actual is RocketLaunchUiState.Loading)
+        }
+    }
+
+    @Test
+    fun `when rocket launch is available then it is returned`() = runTest() {
+        val expectedLaunch = LaunchSampleData.rocketLaunch
+        val mockApi = mockApi(expectedLaunch)
+        val mockSavedState = mockk<SavedStateHandle> {
+            every { get<String>(any()) } returns expectedLaunch.id
+        }
+
+        RocketLaunchViewModel(
+            RocketLaunchRepository(mockApi),
+            mockSavedState,
+            StandardTestDispatcher(testScheduler)
+        ).run {
+            val actual = uiState.take(2).last()
+            assertEquals(
+                expectedLaunch,
+                (actual as? RocketLaunchUiState.Success)?.launch
+            )
+        }
+    }
+
+    @Test
+    fun `when a launch list is not available then it is returned`() = runTest() {
+        val expectedLaunch = LaunchSampleData.rocketLaunch
+        val mockApi = mockk<LaunchesApi> {
+            coEvery { getRocketLaunch(any()) } answers {
+                throw NetworkErrorException()
+            }
+        }
+        val mockSavedState = mockk<SavedStateHandle> {
+            every { get<String>(any()) } returns expectedLaunch.id
+        }
+
+        RocketLaunchViewModel(
+            RocketLaunchRepository(mockApi),
+            mockSavedState,
+            StandardTestDispatcher(testScheduler)
+        ).run {
+            val actual = uiState.take(2).last()
+            Assert.assertTrue(
+                "UI state ($actual) is not an error",
+                actual is RocketLaunchUiState.Error
+            )
+        }
+    }
+}

--- a/app/src/test/java/com/washuTechnologies/merced/intergrationtest/ui/launchlist/LaunchListViewModelIntegrationTest.kt
+++ b/app/src/test/java/com/washuTechnologies/merced/intergrationtest/ui/launchlist/LaunchListViewModelIntegrationTest.kt
@@ -5,7 +5,7 @@ import com.washuTechnologies.merced.api.launches.LaunchesApi
 import com.washuTechnologies.merced.api.launches.RocketLaunchRepository
 import com.washuTechnologies.merced.ui.launchlist.LaunchListUiState
 import com.washuTechnologies.merced.ui.launchlist.LaunchListViewModel
-import com.washuTechnologies.merced.ui.launchlist.LaunchSampleData
+import com.washuTechnologies.merced.util.LaunchSampleData
 import io.mockk.coEvery
 import io.mockk.mockk
 import kotlinx.coroutines.ExperimentalCoroutinesApi

--- a/app/src/test/java/com/washuTechnologies/merced/unittest/ui/launchlist/LaunchListViewModelUnitTest.kt
+++ b/app/src/test/java/com/washuTechnologies/merced/unittest/ui/launchlist/LaunchListViewModelUnitTest.kt
@@ -4,17 +4,15 @@ import com.washuTechnologies.merced.api.Result
 import com.washuTechnologies.merced.api.launches.RocketLaunchRepository
 import com.washuTechnologies.merced.ui.launchlist.LaunchListUiState
 import com.washuTechnologies.merced.ui.launchlist.LaunchListViewModel
-import com.washuTechnologies.merced.ui.launchlist.LaunchSampleData
+import com.washuTechnologies.merced.util.LaunchSampleData
 import io.mockk.every
 import io.mockk.mockk
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.last
 import kotlinx.coroutines.flow.take
 import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.runTest
-import org.junit.Assert
 import org.junit.Assert.assertTrue
 import org.junit.Test
 

--- a/app/src/test/java/com/washuTechnologies/merced/util/LaunchSampleData.kt
+++ b/app/src/test/java/com/washuTechnologies/merced/util/LaunchSampleData.kt
@@ -1,4 +1,4 @@
-package com.washuTechnologies.merced.ui.launchlist
+package com.washuTechnologies.merced.util
 
 import com.washuTechnologies.merced.api.launches.RocketLaunch
 
@@ -6,6 +6,12 @@ import com.washuTechnologies.merced.api.launches.RocketLaunch
  * Sample rocket launch data for use in testing.
  */
 object LaunchSampleData {
+
+    /**
+     * Sample rocket launch.
+     */
+    val rocketLaunch: RocketLaunch
+        get() = sampleLaunches.first()
 
     /**
      * Sample list of rocket launches.

--- a/app/src/test/java/com/washuTechnologies/merced/util/MockHelper.kt
+++ b/app/src/test/java/com/washuTechnologies/merced/util/MockHelper.kt
@@ -8,6 +8,6 @@ import io.mockk.mockk
 object MockHelper {
 
     fun mockApi(rocketLaunch: RocketLaunch) = mockk<LaunchesApi> {
-        coEvery { getRocketLaunch(rocketLaunch.id) } returns LaunchSampleData.rocketLaunch
+        coEvery { getRocketLaunch(rocketLaunch.id) } returns rocketLaunch
     }
 }

--- a/app/src/test/java/com/washuTechnologies/merced/util/MockHelper.kt
+++ b/app/src/test/java/com/washuTechnologies/merced/util/MockHelper.kt
@@ -1,0 +1,13 @@
+package com.washuTechnologies.merced.util
+
+import com.washuTechnologies.merced.api.launches.LaunchesApi
+import com.washuTechnologies.merced.api.launches.RocketLaunch
+import io.mockk.coEvery
+import io.mockk.mockk
+
+object MockHelper {
+
+    fun mockApi(rocketLaunch: RocketLaunch) = mockk<LaunchesApi> {
+        coEvery { getRocketLaunch(rocketLaunch.id) } returns LaunchSampleData.rocketLaunch
+    }
+}


### PR DESCRIPTION
Add a placeholder screen to display information about a specific rocket launch. Update the repository and API class to support queries for a single launch and add supporting integration tests.

![Screenshot_20220327_194726](https://user-images.githubusercontent.com/8459796/160296096-a34943c2-d417-4aa2-b62e-2822c8000a6a.png)
