### PR TITLE
chore: add dependabot to update project and Github actions dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,14 @@
+version: 2
+updates:
+# Update Gradle dependencies used in the project
+  - package-ecosystem: "gradle"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    open-pull-requests-limit: 10
+# Update Github Actions tasks
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+


### PR DESCRIPTION
Automate the creation of PRs to update android project dependencies as well as tasks used with the GitHub actions pipeline