### PR TITLE
feat: add cache support for launch detail screen

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -79,6 +79,7 @@ dependencies {
 
     // Room
     implementation "androidx.room:room-runtime:$room_version"
+    implementation "androidx.room:room-ktx:$room_version"
     annotationProcessor "androidx.room:room-compiler:$room_version"
     kapt "androidx.room:room-compiler:$room_version"
 

--- a/app/src/main/java/com/washuTechnologies/merced/data/launches/datasources/LaunchesLocalDatasource.kt
+++ b/app/src/main/java/com/washuTechnologies/merced/data/launches/datasources/LaunchesLocalDatasource.kt
@@ -5,12 +5,22 @@ import androidx.room.Insert
 import androidx.room.OnConflictStrategy
 import androidx.room.Query
 import com.washuTechnologies.merced.data.launches.model.RocketLaunch
+import kotlinx.coroutines.flow.Flow
 
 @Dao
 interface LaunchesLocalDatasource {
     @Query("SELECT * FROM rocketlaunch")
-    fun getAll(): Array<RocketLaunch>
+    fun getAll(): Flow<Array<RocketLaunch>>
+
+    @Query("SELECT * FROM rocketlaunch WHERE id LIKE :searchId")
+    fun getLaunch(searchId: String): Flow<RocketLaunch?>
+
+    @Query("SELECT COUNT(*) FROM rocketlaunch WHERE id LIKE :searchId")
+    fun hasLaunch(searchId: String): Boolean
 
     @Insert(onConflict = OnConflictStrategy.REPLACE)
     fun insertAll(launchList: Array<RocketLaunch>): Array<Long>
+
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    fun insert(launchList: RocketLaunch): Long
 }

--- a/app/src/main/java/com/washuTechnologies/merced/ui/launchdetail/RocketLaunchViewModel.kt
+++ b/app/src/main/java/com/washuTechnologies/merced/ui/launchdetail/RocketLaunchViewModel.kt
@@ -3,7 +3,6 @@ package com.washuTechnologies.merced.ui.launchdetail
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import com.washuTechnologies.merced.data.Result
 import com.washuTechnologies.merced.data.launches.RocketLaunchRepository
 import com.washuTechnologies.merced.di.IoDispatcher
 import com.washuTechnologies.merced.ui.navigation.Screen
@@ -48,11 +47,13 @@ class RocketLaunchViewModel @Inject constructor(
             // Let users see the fancy animation for a moment.
             delay(300)
             launchRepository.getRocketLaunch(launchId).collect {
-                when (it) {
-                    is Result.Success -> _uiState.emit(RocketLaunchUiState.fromRocketLaunch(it.result))
-                    is Result.Loading -> _uiState.emit(RocketLaunchUiState.Loading)
-                    is Result.Error -> _uiState.emit(RocketLaunchUiState.Error)
+                Timber.d("Launch list state $it.")
+                val state = if (it != null) {
+                    RocketLaunchUiState.fromRocketLaunch(it)
+                } else {
+                    RocketLaunchUiState.Error
                 }
+                _uiState.emit(state)
             }
         }
     }

--- a/app/src/main/java/com/washuTechnologies/merced/usecases/GetRocketListUseCase.kt
+++ b/app/src/main/java/com/washuTechnologies/merced/usecases/GetRocketListUseCase.kt
@@ -5,9 +5,15 @@ import com.washuTechnologies.merced.data.launches.model.RocketLaunch
 import kotlinx.coroutines.flow.Flow
 import javax.inject.Inject
 
+/**
+ * Use Case to retrieve a list of rocket launches.
+ */
 class GetRocketListUseCase @Inject constructor(
     private val rocketLaunchRepository: RocketLaunchRepository
 ) {
 
+    /**
+     * Returns a flow containing the launch list.
+     */
     operator fun invoke(): Flow<Array<RocketLaunch>> = rocketLaunchRepository.getLaunchList()
 }

--- a/app/src/main/java/com/washuTechnologies/merced/usecases/GetRocketListUseCase.kt
+++ b/app/src/main/java/com/washuTechnologies/merced/usecases/GetRocketListUseCase.kt
@@ -1,0 +1,13 @@
+package com.washuTechnologies.merced.usecases
+
+import com.washuTechnologies.merced.data.launches.RocketLaunchRepository
+import com.washuTechnologies.merced.data.launches.model.RocketLaunch
+import kotlinx.coroutines.flow.Flow
+import javax.inject.Inject
+
+class GetRocketListUseCase @Inject constructor(
+    private val rocketLaunchRepository: RocketLaunchRepository
+) {
+
+    operator fun invoke(): Flow<Array<RocketLaunch>> = rocketLaunchRepository.getLaunchList()
+}

--- a/app/src/test/java/com/washuTechnologies/merced/unittest/ui/launchlist/LaunchListViewModelUnitTest.kt
+++ b/app/src/test/java/com/washuTechnologies/merced/unittest/ui/launchlist/LaunchListViewModelUnitTest.kt
@@ -1,9 +1,9 @@
 package com.washuTechnologies.merced.unittest.ui.launchlist
 
-import com.washuTechnologies.merced.data.Result
 import com.washuTechnologies.merced.data.launches.RocketLaunchRepository
 import com.washuTechnologies.merced.ui.launchlist.LaunchListUiState
 import com.washuTechnologies.merced.ui.launchlist.LaunchListViewModel
+import com.washuTechnologies.merced.usecases.GetRocketListUseCase
 import com.washuTechnologies.merced.util.SampleData
 import io.mockk.every
 import io.mockk.mockk
@@ -23,12 +23,12 @@ class LaunchListViewModelUnitTest {
     fun `when a launch list is available then it is returned`() = runTest() {
         val mockRepository = mockk<RocketLaunchRepository> {
             every { getLaunchList() } returns flow {
-                emit(Result.Success(SampleData.launchList))
+                emit(SampleData.launchList)
             }
         }
 
         LaunchListViewModel(
-            mockRepository,
+            GetRocketListUseCase(mockRepository),
             StandardTestDispatcher(testScheduler)
         ).run {
             val actual: LaunchListUiState = uiState.take(2).last()
@@ -40,15 +40,15 @@ class LaunchListViewModelUnitTest {
     }
 
     @Test
-    fun `when a launch list is not available then it is returned`() = runTest() {
+    fun `when a launch list is not available then an error is returned`() = runTest() {
         val mockRepository = mockk<RocketLaunchRepository> {
             every { getLaunchList() } returns flow {
-                emit(Result.Error)
+                emit(emptyArray())
             }
         }
 
         LaunchListViewModel(
-            mockRepository,
+            GetRocketListUseCase(mockRepository),
             StandardTestDispatcher(testScheduler)
         ).run {
             val actual: LaunchListUiState = uiState.take(2).last()

--- a/app/src/test/java/com/washuTechnologies/merced/util/MockDatasourceHelper.kt
+++ b/app/src/test/java/com/washuTechnologies/merced/util/MockDatasourceHelper.kt
@@ -1,26 +1,28 @@
 package com.washuTechnologies.merced.util
 
+import com.washuTechnologies.merced.data.connectivity.ConnectivityDatasource
+import com.washuTechnologies.merced.data.launches.datasources.LaunchesLocalDatasource
 import com.washuTechnologies.merced.data.launches.datasources.LaunchesRemoteDatasource
 import com.washuTechnologies.merced.data.launches.model.RocketLaunch
-import com.washuTechnologies.merced.data.launches.datasources.LaunchesLocalDatasource
-import com.washuTechnologies.merced.data.connectivity.ConnectivityDatasource
 import io.mockk.coEvery
 import io.mockk.every
 import io.mockk.mockk
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.flow
 
 object MockDatasourceHelper {
 
-    fun launchesRemoteDatasource(launch: RocketLaunch) =
-        launchesRemoteDatasource(launchList = arrayOf(launch))
+    fun mockLaunchesRemoteDatasource(launch: RocketLaunch) =
+        mockLaunchesRemoteDatasource(launchList = arrayOf(launch))
 
-    fun launchesRemoteDatasource(launchList: Array<RocketLaunch> = arrayOf()) = mockk<LaunchesRemoteDatasource> {
-        coEvery { getRocketLaunchList() } returns launchList
-        coEvery { getRocketLaunch(any()) } answers {
-            launchList.first() { it.id == args.first() }
+    fun mockLaunchesRemoteDatasource(launchList: Array<RocketLaunch> = arrayOf()) =
+        mockk<LaunchesRemoteDatasource> {
+            coEvery { getRocketLaunchList() } returns launchList
+            coEvery { getRocketLaunch(any()) } answers {
+                launchList.first() { it.id == args.first() }
+            }
         }
-    }
 
     fun mockConnectivity(isConnected: Boolean) = mockConnectivity(flow { emit(isConnected) })
 
@@ -29,9 +31,32 @@ object MockDatasourceHelper {
             every { hasConnectivity } returns connectivityState
         }
 
+    fun mockLaunchesLocalSource(launch: RocketLaunch) = mockLaunchesLocalSource(arrayOf(launch))
+
+    @Suppress("UNCHECKED_CAST")
     fun mockLaunchesLocalSource(launchList: Array<RocketLaunch> = emptyArray()) =
         mockk<LaunchesLocalDatasource> {
-            every { getAll() } returns launchList
-            every { insertAll(any()) } returns emptyArray()
+            val launchListFlow = MutableStateFlow(launchList)
+            var rocketFlow: MutableStateFlow<RocketLaunch?>? = null
+
+            every { getAll() } returns launchListFlow
+            every { insertAll(any()) } answers {
+                launchListFlow.value = args.first() as Array<RocketLaunch>
+                Array(args.size) { Math.random().toLong() }
+            }
+            every { insert(any()) } answers {
+                rocketFlow?.value = args.first() as RocketLaunch
+                1
+            }
+            every { getLaunch(any()) } answers {
+                if (rocketFlow == null) {
+                    rocketFlow =
+                        MutableStateFlow(launchList.firstOrNull { it.id == args.first() })
+                }
+                rocketFlow as Flow<RocketLaunch>
+            }
+            every { hasLaunch(any()) } answers {
+                launchList.firstOrNull { it.id == args.first() } != null
+            }
         }
 }

--- a/app/src/test/java/com/washuTechnologies/merced/util/MockRepositoryHelper.kt
+++ b/app/src/test/java/com/washuTechnologies/merced/util/MockRepositoryHelper.kt
@@ -8,11 +8,11 @@ import com.washuTechnologies.merced.data.connectivity.ConnectivityDatasource
 object RepositoryHelper {
 
     fun launchesRepository(
-        launchesRemoteDatasource: LaunchesRemoteDatasource = MockDatasourceHelper.launchesRemoteDatasource(),
+        remoteDatasource: LaunchesRemoteDatasource = MockDatasourceHelper.mockLaunchesRemoteDatasource(),
         localDatasource: LaunchesLocalDatasource = MockDatasourceHelper.mockLaunchesLocalSource(),
         connectivityDatasource: ConnectivityDatasource = MockDatasourceHelper.mockConnectivity()
     ) = RocketLaunchRepository(
-        remoteDatasource = launchesRemoteDatasource,
+        remoteDatasource = remoteDatasource,
         localDatasource = localDatasource,
         connectivityDatasource = connectivityDatasource
     )


### PR DESCRIPTION
Update the repository to accessed a cache result if the user navigates to a particular rocket launch while they are offline.