### PR TITLE
Feat: Show offline alert to the user on list and detail screens

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -56,8 +56,8 @@ dependencies {
     implementation "androidx.compose.material3:material3:$material_version"
     implementation "androidx.compose.ui:ui-tooling-preview:$compose_version"
     implementation "androidx.compose.material:material-icons-extended:$compose_version"
-    implementation 'androidx.lifecycle:lifecycle-runtime-ktx:2.4.1'
-    implementation 'androidx.activity:activity-compose:1.4.0'
+    implementation 'androidx.lifecycle:lifecycle-runtime-ktx:2.5.1'
+    implementation 'androidx.activity:activity-compose:1.5.1'
     implementation "androidx.navigation:navigation-compose:$nav_version"
     implementation "com.google.accompanist:accompanist-systemuicontroller:0.26.2-beta"
     implementation "com.jakewharton.timber:timber:5.0.1"

--- a/app/src/main/java/com/washuTechnologies/merced/data/AppState.kt
+++ b/app/src/main/java/com/washuTechnologies/merced/data/AppState.kt
@@ -1,0 +1,12 @@
+package com.washuTechnologies.merced.data
+
+/**
+ * Model object representing global app state information.
+ */
+data class AppState(
+    val isInternetConnected: Boolean
+) {
+    companion object {
+        val DEFAULT = AppState(true)
+    }
+}

--- a/app/src/main/java/com/washuTechnologies/merced/data/connectivity/ConnectivityDatasource.kt
+++ b/app/src/main/java/com/washuTechnologies/merced/data/connectivity/ConnectivityDatasource.kt
@@ -4,15 +4,17 @@ import android.net.ConnectivityManager
 import android.net.Network
 import android.net.NetworkCapabilities
 import android.net.NetworkRequest
+import javax.inject.Inject
+import javax.inject.Singleton
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
-import javax.inject.Inject
 import timber.log.Timber
 
 /**
  * Datasource making information about the mobile device connectivity state available to
  * other parts of the app.
  */
+@Singleton
 class ConnectivityDatasource @Inject constructor(
     connectivityManager: ConnectivityManager
 ) {

--- a/app/src/main/java/com/washuTechnologies/merced/data/connectivity/ConnectivityDatasource.kt
+++ b/app/src/main/java/com/washuTechnologies/merced/data/connectivity/ConnectivityDatasource.kt
@@ -7,6 +7,7 @@ import android.net.NetworkRequest
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import javax.inject.Inject
+import timber.log.Timber
 
 /**
  * Datasource making information about the mobile device connectivity state available to
@@ -16,21 +17,32 @@ class ConnectivityDatasource @Inject constructor(
     connectivityManager: ConnectivityManager
 ) {
 
-    private val _hasConnectivity = MutableStateFlow(false)
-    val hasConnectivity: Flow<Boolean>
-        get() = _hasConnectivity
+    private val _isInternetConnected = MutableStateFlow(false)
+
+    /**
+     * Internet connectivity state.
+     */
+    val isInternetConnected: Flow<Boolean>
+        get() = _isInternetConnected
 
     init {
         connectivityManager.registerNetworkCallback(networkRequest, object :
             ConnectivityManager.NetworkCallback() {
             override fun onAvailable(network: Network) {
                 super.onAvailable(network)
-                _hasConnectivity.value = true
+                Timber.d("Network available")
+                _isInternetConnected.value = true
             }
 
             override fun onLost(network: Network) {
                 super.onLost(network)
-                _hasConnectivity.value = false
+                Timber.d("Network lost")
+                _isInternetConnected.value = false
+            }
+
+            override fun onUnavailable() {
+                Timber.d("Network unavailable")
+                super.onUnavailable()
             }
         })
     }

--- a/app/src/main/java/com/washuTechnologies/merced/data/connectivity/ConnectivityRepository.kt
+++ b/app/src/main/java/com/washuTechnologies/merced/data/connectivity/ConnectivityRepository.kt
@@ -1,0 +1,16 @@
+package com.washuTechnologies.merced.data.connectivity
+
+import javax.inject.Inject
+
+/**
+ * Repository class for accessing mobile device connectivity state.
+ */
+class ConnectivityRepository @Inject constructor(
+    connectivityDatasource: ConnectivityDatasource
+) {
+
+    /**
+     * Retrieve the device connectivity state.
+     */
+    val connectivityState = connectivityDatasource.isInternetConnected
+}

--- a/app/src/main/java/com/washuTechnologies/merced/data/launches/RocketLaunchRepository.kt
+++ b/app/src/main/java/com/washuTechnologies/merced/data/launches/RocketLaunchRepository.kt
@@ -33,7 +33,7 @@ class RocketLaunchRepository @Inject constructor(
     }
 
     private suspend fun checkForLaunchListUpdate() {
-        if (!connectivityDatasource.hasConnectivity.first()) {
+        if (!connectivityDatasource.isInternetConnected.first()) {
             Timber.e("Unable to sync launch list, not connected")
             return
         }
@@ -59,7 +59,7 @@ class RocketLaunchRepository @Inject constructor(
         }
 
     private suspend fun getRemoteLaunch(launchId: String) {
-        if (!connectivityDatasource.hasConnectivity.first()) {
+        if (!connectivityDatasource.isInternetConnected.first()) {
             Timber.e("Unable to sync launch list, not connected")
             return
         }

--- a/app/src/main/java/com/washuTechnologies/merced/data/launches/model/RocketLaunch.kt
+++ b/app/src/main/java/com/washuTechnologies/merced/data/launches/model/RocketLaunch.kt
@@ -20,7 +20,7 @@ data class RocketLaunch(
     @Json(name = "name")
     val name: String,
     @Json(name = "date_utc")
-    val dateUTC: String,
+    val launchDateUTC: String,
     @Json(name = "static_fire_date_utc")
     val staticFireDateUTC: String?,
     @Json(name = "details")

--- a/app/src/main/java/com/washuTechnologies/merced/data/launches/model/RocketLaunch.kt
+++ b/app/src/main/java/com/washuTechnologies/merced/data/launches/model/RocketLaunch.kt
@@ -36,7 +36,8 @@ data class RocketLaunch(
      * Retrieves the first image of the launch if any are present.
      */
     fun findImage(): String? =
-        links?.flickr?.small?.firstOrNull() ?: links?.flickr?.original?.firstOrNull()
+        links?.flickr?.small?.firstOrNull { it.isNotBlank() }
+            ?: links?.flickr?.original?.firstOrNull { it.isNotBlank() }
 
     companion object {
         /**

--- a/app/src/main/java/com/washuTechnologies/merced/di/ApiModule.kt
+++ b/app/src/main/java/com/washuTechnologies/merced/di/ApiModule.kt
@@ -5,11 +5,13 @@ import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
 import dagger.hilt.components.SingletonComponent
+import javax.inject.Singleton
 
 @Module
 @InstallIn(SingletonComponent::class)
 object ApiModule {
 
     @Provides
+    @Singleton
     fun launchesApi(): LaunchesRemoteDatasource = LaunchesRemoteDatasource.create()
 }

--- a/app/src/main/java/com/washuTechnologies/merced/di/RoomModule.kt
+++ b/app/src/main/java/com/washuTechnologies/merced/di/RoomModule.kt
@@ -8,12 +8,14 @@ import dagger.Provides
 import dagger.hilt.InstallIn
 import dagger.hilt.android.qualifiers.ApplicationContext
 import dagger.hilt.components.SingletonComponent
+import javax.inject.Singleton
 
 @Module
 @InstallIn(SingletonComponent::class)
 object RoomModule {
 
     @Provides
+    @Singleton
     fun launchesDatabase(@ApplicationContext applicationContext: Context): SpaceXDatabase =
         Room.databaseBuilder(
             applicationContext,

--- a/app/src/main/java/com/washuTechnologies/merced/domain/connectivity/GetConnectivityStateUseCase.kt
+++ b/app/src/main/java/com/washuTechnologies/merced/domain/connectivity/GetConnectivityStateUseCase.kt
@@ -1,0 +1,17 @@
+package com.washuTechnologies.merced.domain.connectivity
+
+import com.washuTechnologies.merced.data.connectivity.ConnectivityRepository
+import javax.inject.Inject
+
+/**
+ * Use Case to retrieve the mobile device internet connectivity state.
+ */
+class GetConnectivityStateUseCase @Inject constructor(
+    private val connectivityDatasource: ConnectivityRepository
+) {
+
+    /**
+     * Returns the mobile device connectivity state.
+     */
+    operator fun invoke() = connectivityDatasource.connectivityState
+}

--- a/app/src/main/java/com/washuTechnologies/merced/domain/connectivity/GetConnectivityStateUseCase.kt
+++ b/app/src/main/java/com/washuTechnologies/merced/domain/connectivity/GetConnectivityStateUseCase.kt
@@ -7,11 +7,11 @@ import javax.inject.Inject
  * Use Case to retrieve the mobile device internet connectivity state.
  */
 class GetConnectivityStateUseCase @Inject constructor(
-    private val connectivityDatasource: ConnectivityRepository
+    private val connectivityRepository: ConnectivityRepository
 ) {
 
     /**
      * Returns the mobile device connectivity state.
      */
-    operator fun invoke() = connectivityDatasource.connectivityState
+    operator fun invoke() = connectivityRepository.connectivityState
 }

--- a/app/src/main/java/com/washuTechnologies/merced/ui/AppViewModel.kt
+++ b/app/src/main/java/com/washuTechnologies/merced/ui/AppViewModel.kt
@@ -1,0 +1,29 @@
+package com.washuTechnologies.merced.ui
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.washuTechnologies.merced.data.AppState
+import com.washuTechnologies.merced.domain.connectivity.GetConnectivityStateUseCase
+import dagger.hilt.android.lifecycle.HiltViewModel
+import javax.inject.Inject
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.stateIn
+
+/**
+ * View model for globally held state information.
+ */
+@HiltViewModel
+class AppViewModel @Inject constructor(
+    getConnectivityStateUseCase: GetConnectivityStateUseCase
+) : ViewModel() {
+
+    val appState: Flow<AppState> = getConnectivityStateUseCase().map {
+        AppState(it)
+    }.stateIn(
+        viewModelScope,
+        SharingStarted.Lazily,
+        AppState.DEFAULT
+    )
+}

--- a/app/src/main/java/com/washuTechnologies/merced/ui/MercedApp.kt
+++ b/app/src/main/java/com/washuTechnologies/merced/ui/MercedApp.kt
@@ -1,6 +1,9 @@
 package com.washuTechnologies.merced.ui
 
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.hilt.navigation.compose.hiltViewModel
+import com.washuTechnologies.merced.data.AppState
 import com.washuTechnologies.merced.ui.components.MercedScaffold
 import com.washuTechnologies.merced.ui.navigation.MercedNavGraph
 import com.washuTechnologies.merced.ui.theme.MercedTheme
@@ -9,10 +12,13 @@ import com.washuTechnologies.merced.ui.theme.MercedTheme
  * Root composable.
  */
 @Composable
-fun MercedApp() {
+fun MercedApp(
+    viewModel: AppViewModel = hiltViewModel(),
+) {
+    val state = viewModel.appState.collectAsState(AppState.DEFAULT)
     MercedTheme {
         MercedScaffold {
-            MercedNavGraph()
+            MercedNavGraph(appState = state.value)
         }
     }
 }

--- a/app/src/main/java/com/washuTechnologies/merced/ui/components/Connectivity.kt
+++ b/app/src/main/java/com/washuTechnologies/merced/ui/components/Connectivity.kt
@@ -1,0 +1,44 @@
+package com.washuTechnologies.merced.ui.components
+
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.material.Card
+import androidx.compose.material.Icon
+import androidx.compose.material.Text
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Warning
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import com.washuTechnologies.merced.R
+
+/**
+ * Card to display a message to the user they are not connected to the internet.
+ */
+@Composable
+fun NotConnectedCard(
+    modifier: Modifier = Modifier
+) {
+    Card(modifier.padding(16.dp)) {
+        Row(
+            modifier = Modifier.padding(16.dp),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Icon(
+                Icons.Filled.Warning,
+                contentDescription = "",
+                modifier = Modifier.size(40.dp)
+            )
+            Text(
+                modifier = Modifier.fillMaxWidth(),
+                textAlign = TextAlign.Center,
+                text = stringResource(id = R.string.internet_not_connected_message)
+            )
+        }
+    }
+}

--- a/app/src/main/java/com/washuTechnologies/merced/ui/launchdetail/LaunchDetailUiState.kt
+++ b/app/src/main/java/com/washuTechnologies/merced/ui/launchdetail/LaunchDetailUiState.kt
@@ -45,7 +45,7 @@ sealed class RocketLaunchUiState {
             name = launch.name,
             image = launch.findImage(),
             details = launch.details,
-            launchDate = DateHelper.utcLaunchDateToDisplay(launch.dateUTC),
+            launchDate = DateHelper.utcLaunchDateToDisplay(launch.launchDateUTC),
             staticFireDate = launch.staticFireDateUTC?.let { DateHelper.utcLaunchDateToDisplay(it) },
             launchLocation = launch.launchpad,
             links = LaunchLinks(

--- a/app/src/main/java/com/washuTechnologies/merced/ui/launchdetail/RocketLaunchDetailScreen.kt
+++ b/app/src/main/java/com/washuTechnologies/merced/ui/launchdetail/RocketLaunchDetailScreen.kt
@@ -24,6 +24,10 @@ import androidx.compose.material.icons.sharp.Movie
 import androidx.compose.material.icons.sharp.Public
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -114,7 +118,7 @@ private fun RocketDetail(
         Header(
             modifier = Modifier.fillMaxWidth(),
             launchName = launch.name,
-            photo = launch.image
+            imageUrl = launch.image
         )
         Spacer(modifier = Modifier.height(16.dp))
         Text(
@@ -131,30 +135,37 @@ private fun RocketDetail(
 private fun Header(
     modifier: Modifier = Modifier,
     launchName: String,
-    photo: String?
+    imageUrl: String?
 ) {
-    if (photo != null) {
-        Row(modifier = modifier) {
+    Column(modifier = modifier) {
+        // If image loading fails remove it from the composition
+        // Better support offline mode where the launch info may be available
+        // but the imager has not previously been cached.
+        var imageLoadFiled by remember { mutableStateOf(false) }
+        if (imageUrl != null && !imageLoadFiled) {
             AsyncImage(
                 modifier = Modifier
                     .heightIn(max = 180.dp)
                     .fillMaxWidth()
                     .clip(shape = MaterialTheme.shapes.medium),
                 model = ImageRequest.Builder(LocalContext.current)
-                    .data(photo)
+                    .data(imageUrl)
                     .crossfade(300)
                     .build(),
                 placeholder = painterResource(R.drawable.image_placeholder),
                 contentDescription = stringResource(R.string.launch_image_content_description),
                 contentScale = ContentScale.Crop,
+                onError = {
+                    imageLoadFiled = true
+                }
             )
         }
+        Text(
+            text = launchName,
+            style = MaterialTheme.typography.h3,
+            textAlign = TextAlign.Center
+        )
     }
-    Text(
-        text = launchName,
-        style = MaterialTheme.typography.h3,
-        textAlign = TextAlign.Center
-    )
 }
 
 @Composable

--- a/app/src/main/java/com/washuTechnologies/merced/ui/launchdetail/RocketLaunchDetailScreen.kt
+++ b/app/src/main/java/com/washuTechnologies/merced/ui/launchdetail/RocketLaunchDetailScreen.kt
@@ -40,8 +40,10 @@ import androidx.hilt.navigation.compose.hiltViewModel
 import coil.compose.AsyncImage
 import coil.request.ImageRequest
 import com.washuTechnologies.merced.R
+import com.washuTechnologies.merced.data.AppState
 import com.washuTechnologies.merced.ui.components.LoadingScreen
 import com.washuTechnologies.merced.ui.components.MercedScaffold
+import com.washuTechnologies.merced.ui.components.NotConnectedCard
 import com.washuTechnologies.merced.ui.components.WebLinkButton
 import com.washuTechnologies.merced.ui.theme.MercedTheme
 import com.washuTechnologies.merced.util.SampleData
@@ -52,19 +54,22 @@ import com.washuTechnologies.merced.util.SampleData
 @Composable
 fun RocketLaunchDetailScreen(
     modifier: Modifier = Modifier,
-    viewModel: RocketLaunchViewModel = hiltViewModel()
+    viewModel: RocketLaunchViewModel = hiltViewModel(),
+    appState: AppState
 ) {
     val launchState = viewModel.uiState.collectAsState()
     RocketLaunchDetailScreen(
         modifier = modifier,
-        rocketLaunchState = launchState.value
+        rocketLaunchState = launchState.value,
+        isInternetConnected = appState.isInternetConnected
     )
 }
 
 @Composable
 private fun RocketLaunchDetailScreen(
     modifier: Modifier = Modifier,
-    rocketLaunchState: RocketLaunchUiState
+    rocketLaunchState: RocketLaunchUiState,
+    isInternetConnected: Boolean
 ) {
     Column(
         modifier = modifier
@@ -73,7 +78,10 @@ private fun RocketLaunchDetailScreen(
     ) {
         when (rocketLaunchState) {
             is RocketLaunchUiState.Success -> {
-                RocketDetail(launch = rocketLaunchState)
+                RocketDetail(
+                    launch = rocketLaunchState,
+                    isInternetConnected = isInternetConnected
+                )
             }
             is RocketLaunchUiState.Error -> {
                 Text(text = stringResource(id = R.string.error_generic_message))
@@ -89,13 +97,20 @@ private fun RocketLaunchDetailScreen(
 }
 
 @Composable
-private fun RocketDetail(modifier: Modifier = Modifier, launch: RocketLaunchUiState.Success) {
+private fun RocketDetail(
+    modifier: Modifier = Modifier,
+    launch: RocketLaunchUiState.Success,
+    isInternetConnected: Boolean
+) {
     Column(
         modifier = modifier
             .fillMaxWidth()
             .verticalScroll(rememberScrollState()),
         horizontalAlignment = Alignment.CenterHorizontally
     ) {
+        if (!isInternetConnected) {
+            NotConnectedCard()
+        }
         Header(
             modifier = Modifier.fillMaxWidth(),
             launchName = launch.name,
@@ -257,7 +272,8 @@ private fun Preview() {
     MercedTheme {
         MercedScaffold {
             RocketLaunchDetailScreen(
-                rocketLaunchState = RocketLaunchUiState.fromRocketLaunch(SampleData.rocketLaunch)
+                rocketLaunchState = RocketLaunchUiState.fromRocketLaunch(SampleData.rocketLaunch),
+                isInternetConnected = false
             )
         }
     }

--- a/app/src/main/java/com/washuTechnologies/merced/ui/launchlist/LaunchListViewModel.kt
+++ b/app/src/main/java/com/washuTechnologies/merced/ui/launchlist/LaunchListViewModel.kt
@@ -6,12 +6,12 @@ import com.washuTechnologies.merced.data.launches.model.RocketLaunch
 import com.washuTechnologies.merced.di.IoDispatcher
 import com.washuTechnologies.merced.usecases.GetRocketListUseCase
 import dagger.hilt.android.lifecycle.HiltViewModel
+import javax.inject.Inject
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.launch
 import timber.log.Timber
-import javax.inject.Inject
 
 /**
  * View model for the list of rocket launches

--- a/app/src/main/java/com/washuTechnologies/merced/ui/launchlist/RocketLaunchListScreen.kt
+++ b/app/src/main/java/com/washuTechnologies/merced/ui/launchlist/RocketLaunchListScreen.kt
@@ -13,7 +13,6 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.shape.CircleShape
-import androidx.compose.material.Card
 import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Text
 import androidx.compose.material.contentColorFor
@@ -23,7 +22,6 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
@@ -31,6 +29,7 @@ import com.washuTechnologies.merced.R
 import com.washuTechnologies.merced.data.AppState
 import com.washuTechnologies.merced.data.launches.model.RocketLaunch
 import com.washuTechnologies.merced.ui.components.LoadingScreen
+import com.washuTechnologies.merced.ui.components.NotConnectedCard
 import com.washuTechnologies.merced.ui.theme.MercedTheme
 import com.washuTechnologies.merced.util.SampleData
 import timber.log.Timber
@@ -100,23 +99,6 @@ private fun LaunchList(
                     onLaunchSelected(selectedId)
                 },
                 launch = item
-            )
-        }
-    }
-}
-
-@Composable
-private fun NotConnectedCard(
-    modifier: Modifier = Modifier
-) {
-    Card(modifier.padding(16.dp)) {
-        Column(
-            modifier = Modifier.padding(16.dp),
-        ) {
-            Text(
-                modifier = Modifier.fillMaxWidth(),
-                textAlign = TextAlign.Center,
-                text = stringResource(id = R.string.internet_not_connected_message)
             )
         }
     }

--- a/app/src/main/java/com/washuTechnologies/merced/ui/launchlist/RocketLaunchListScreen.kt
+++ b/app/src/main/java/com/washuTechnologies/merced/ui/launchlist/RocketLaunchListScreen.kt
@@ -13,6 +13,7 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.material.Card
 import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Text
 import androidx.compose.material.contentColorFor
@@ -22,10 +23,12 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import com.washuTechnologies.merced.R
+import com.washuTechnologies.merced.data.AppState
 import com.washuTechnologies.merced.data.launches.model.RocketLaunch
 import com.washuTechnologies.merced.ui.components.LoadingScreen
 import com.washuTechnologies.merced.ui.theme.MercedTheme
@@ -37,23 +40,33 @@ import timber.log.Timber
  */
 @Composable
 fun RocketLaunchListScreen(
+    appState: AppState,
     viewModel: LaunchListViewModel = hiltViewModel(),
     onLaunchSelected: (String) -> Unit
 ) {
-    val list = viewModel.uiState.collectAsState()
-    RocketLaunchListScreen(launchList = list.value, onLaunchSelected = onLaunchSelected)
+    val list = viewModel.uiState.collectAsState(LaunchListUiState.Loading)
+    RocketLaunchListScreen(
+        isInternetConnected = appState.isInternetConnected,
+        launchList = list.value,
+        onLaunchSelected = onLaunchSelected
+    )
 }
 
 @Composable
 private fun RocketLaunchListScreen(
+    modifier: Modifier = Modifier,
+    isInternetConnected: Boolean,
     launchList: LaunchListUiState,
     onLaunchSelected: (String) -> Unit = {}
 ) {
     Column(
-        modifier = Modifier.fillMaxSize()
+        modifier = modifier.fillMaxSize()
     ) {
         when (launchList) {
             is LaunchListUiState.Success -> {
+                if (!isInternetConnected) {
+                    NotConnectedCard()
+                }
                 LaunchList(launchList = launchList.launchList, onLaunchSelected)
             }
             is LaunchListUiState.Error -> {
@@ -80,6 +93,23 @@ private fun LaunchList(
                     onLaunchSelected(selectedId)
                 },
                 launch = item
+            )
+        }
+    }
+}
+
+@Composable
+private fun NotConnectedCard(
+    modifier: Modifier = Modifier
+) {
+    Card(modifier.padding(4.dp)) {
+        Column(
+            modifier = Modifier.padding(4.dp),
+        ) {
+            Text(
+                modifier = Modifier.fillMaxWidth(),
+                textAlign = TextAlign.Center,
+                text = stringResource(id = R.string.internet_not_connected_message)
             )
         }
     }
@@ -132,6 +162,7 @@ private fun LaunchNumber(modifier: Modifier = Modifier, flightNumber: Int) {
 private fun Preview() {
     MercedTheme {
         RocketLaunchListScreen(
+            isInternetConnected = true,
             launchList = LaunchListUiState.Success(SampleData.launchList)
         )
     }
@@ -142,6 +173,7 @@ private fun Preview() {
 private fun LoadingPreview() {
     MercedTheme {
         RocketLaunchListScreen(
+            isInternetConnected = true,
             launchList = LaunchListUiState.Loading
         )
     }
@@ -152,6 +184,7 @@ private fun LoadingPreview() {
 private fun ErrorPreview() {
     MercedTheme {
         RocketLaunchListScreen(
+            isInternetConnected = false,
             launchList = LaunchListUiState.Error
         )
     }

--- a/app/src/main/java/com/washuTechnologies/merced/ui/launchlist/RocketLaunchListScreen.kt
+++ b/app/src/main/java/com/washuTechnologies/merced/ui/launchlist/RocketLaunchListScreen.kt
@@ -64,10 +64,11 @@ private fun RocketLaunchListScreen(
     ) {
         when (launchList) {
             is LaunchListUiState.Success -> {
-                if (!isInternetConnected) {
-                    NotConnectedCard()
-                }
-                LaunchList(launchList = launchList.launchList, onLaunchSelected)
+                LaunchList(
+                    launchList = launchList.launchList,
+                    isInternetConnected = isInternetConnected,
+                    onLaunchSelected = onLaunchSelected
+                )
             }
             is LaunchListUiState.Error -> {
                 Text(text = stringResource(id = R.string.error_generic_message))
@@ -82,9 +83,15 @@ private fun RocketLaunchListScreen(
 @Composable
 private fun LaunchList(
     launchList: Array<RocketLaunch>,
+    isInternetConnected: Boolean,
     onLaunchSelected: (String) -> Unit
 ) {
     LazyColumn {
+        item {
+            if (!isInternetConnected) {
+                NotConnectedCard()
+            }
+        }
         items(items = launchList) { item ->
             LaunchSummary(
                 modifier = Modifier.clickable {
@@ -102,9 +109,9 @@ private fun LaunchList(
 private fun NotConnectedCard(
     modifier: Modifier = Modifier
 ) {
-    Card(modifier.padding(4.dp)) {
+    Card(modifier.padding(16.dp)) {
         Column(
-            modifier = Modifier.padding(4.dp),
+            modifier = Modifier.padding(16.dp),
         ) {
             Text(
                 modifier = Modifier.fillMaxWidth(),
@@ -162,7 +169,7 @@ private fun LaunchNumber(modifier: Modifier = Modifier, flightNumber: Int) {
 private fun Preview() {
     MercedTheme {
         RocketLaunchListScreen(
-            isInternetConnected = true,
+            isInternetConnected = false,
             launchList = LaunchListUiState.Success(SampleData.launchList)
         )
     }

--- a/app/src/main/java/com/washuTechnologies/merced/ui/navigation/NavHost.kt
+++ b/app/src/main/java/com/washuTechnologies/merced/ui/navigation/NavHost.kt
@@ -8,6 +8,7 @@ import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.navigation.compose.rememberNavController
 import androidx.navigation.navArgument
+import com.washuTechnologies.merced.data.AppState
 import com.washuTechnologies.merced.ui.launchdetail.RocketLaunchDetailScreen
 import com.washuTechnologies.merced.ui.launchlist.RocketLaunchListScreen
 
@@ -17,6 +18,7 @@ import com.washuTechnologies.merced.ui.launchlist.RocketLaunchListScreen
 @Composable
 fun MercedNavGraph(
     modifier: Modifier = Modifier,
+    appState: AppState,
     navController: NavHostController = rememberNavController(),
     startDestination: String = Screen.LaunchList.route
 ) {
@@ -26,7 +28,7 @@ fun MercedNavGraph(
         modifier = modifier
     ) {
         composable(Screen.LaunchList.route) {
-            RocketLaunchListScreen() {
+            RocketLaunchListScreen(appState) {
                 navController.navigate(Screen.LaunchDetail.create(it))
             }
         }

--- a/app/src/main/java/com/washuTechnologies/merced/ui/navigation/NavHost.kt
+++ b/app/src/main/java/com/washuTechnologies/merced/ui/navigation/NavHost.kt
@@ -38,7 +38,7 @@ fun MercedNavGraph(
                 type = NavType.StringType
             })
         ) {
-            RocketLaunchDetailScreen()
+            RocketLaunchDetailScreen(appState = appState)
         }
     }
 }

--- a/app/src/main/java/com/washuTechnologies/merced/usecases/GetRocketListUseCase.kt
+++ b/app/src/main/java/com/washuTechnologies/merced/usecases/GetRocketListUseCase.kt
@@ -2,18 +2,23 @@ package com.washuTechnologies.merced.usecases
 
 import com.washuTechnologies.merced.data.launches.RocketLaunchRepository
 import com.washuTechnologies.merced.data.launches.model.RocketLaunch
+import com.washuTechnologies.merced.di.IoDispatcher
 import javax.inject.Inject
+import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flowOn
 
 /**
  * Use Case to retrieve a list of rocket launches.
  */
 class GetRocketListUseCase @Inject constructor(
-    private val rocketLaunchRepository: RocketLaunchRepository
+    private val rocketLaunchRepository: RocketLaunchRepository,
+    @IoDispatcher val dispatcher: CoroutineDispatcher
 ) {
 
     /**
      * Returns a flow containing the launch list.
      */
-    operator fun invoke(): Flow<Array<RocketLaunch>> = rocketLaunchRepository.getLaunchList()
+    operator fun invoke(): Flow<Array<RocketLaunch>> =
+        rocketLaunchRepository.getLaunchList().flowOn(dispatcher)
 }

--- a/app/src/main/java/com/washuTechnologies/merced/util/SampleData.kt
+++ b/app/src/main/java/com/washuTechnologies/merced/util/SampleData.kt
@@ -26,7 +26,7 @@ object SampleData {
                 id = "5eb87cd9ffd86e000604b32a",
                 flightNumber = 1,
                 name = "FalconSat",
-                dateUTC = "2006-03-24T22:30:00.000Z",
+                launchDateUTC = "2006-03-24T22:30:00.000Z",
                 staticFireDateUTC = "2006-02-24T22:30:00.000Z",
                 details = "Engine failure at 33 seconds and loss of vehicle",
                 links = Links(
@@ -50,7 +50,7 @@ object SampleData {
                 id = "5e9d0d95eda69955f709d1eb",
                 flightNumber = 2,
                 name = "DemoSat",
-                dateUTC = "2007-03-21T01:10:00.000Z",
+                launchDateUTC = "2007-03-21T01:10:00.000Z",
                 staticFireDateUTC = "2006-02-24T22:30:00.000Z",
                 details = "Successful first stage burn and transition to second stage, maximum altitude 289 km, Premature engine shutdown at T+7 min 30 s, Failed to reach orbit, Failed to recover first stage"
             ),
@@ -58,7 +58,7 @@ object SampleData {
                 id = "5e9d0d95eda69955f709d1eb",
                 flightNumber = 3,
                 name = "Trailblazer",
-                dateUTC = "2008-09-28T23:15:00.000Z",
+                launchDateUTC = "2008-09-28T23:15:00.000Z",
                 staticFireDateUTC = "2006-02-24T22:30:00.000Z",
                 details = "Residual stage 1 thrust led to collision between stage 1 and stage 2"
             )

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -12,4 +12,5 @@
     <string name="link_press_kit">Press Kit</string>
     <string name="link_article">Article</string>
     <string name="link_youtube">Youtube</string>
+    <string name="internet_not_connected_message">Looks like you\'re not connected to the internet. Launch information is not up to date as you are not connected to the internet</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -12,5 +12,5 @@
     <string name="link_press_kit">Press Kit</string>
     <string name="link_article">Article</string>
     <string name="link_youtube">Youtube</string>
-    <string name="internet_not_connected_message">Looks like you\'re not connected to the internet. Launch information is not up to date as you are not connected to the internet</string>
+    <string name="internet_not_connected_message">Looks like you\'re not connected to the internet. Launch information may not be up to date</string>
 </resources>

--- a/app/src/test/java/com/washuTechnologies/merced/intergrationtest/ui/AppViewModelTest.kt
+++ b/app/src/test/java/com/washuTechnologies/merced/intergrationtest/ui/AppViewModelTest.kt
@@ -1,0 +1,52 @@
+package com.washuTechnologies.merced.intergrationtest.ui
+
+import com.washuTechnologies.merced.data.connectivity.ConnectivityRepository
+import com.washuTechnologies.merced.domain.connectivity.GetConnectivityStateUseCase
+import com.washuTechnologies.merced.ui.AppViewModel
+import com.washuTechnologies.merced.util.MockDatasourceHelper
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class AppViewModelTest {
+
+    @Test
+    fun `when connected the app state is correct`() = runTest {
+        val connectivityRepo = ConnectivityRepository(
+            MockDatasourceHelper.mockConnectivity(true)
+        )
+
+        // Given the device is connected to the internet
+        AppViewModel(
+            GetConnectivityStateUseCase(connectivityRepo)
+        ).run {
+            // When app state is emitted
+            val state = appState.first()
+
+            // Then the connectivity state is correct
+            assertTrue(state.isInternetConnected)
+        }
+    }
+
+    @Test
+    fun `when not connected the app state is correct`() = runTest {
+        val connectivityRepo = ConnectivityRepository(
+            MockDatasourceHelper.mockConnectivity(false)
+        )
+
+        // Given the device is not connected to the internet
+        AppViewModel(
+            GetConnectivityStateUseCase(connectivityRepo)
+        ).run {
+            // When app state is emitted
+            val state = appState.first()
+
+            // Then the connectivity state is correct
+            assertFalse(state.isInternetConnected)
+        }
+    }
+}

--- a/app/src/test/java/com/washuTechnologies/merced/intergrationtest/ui/AppViewModelTest.kt
+++ b/app/src/test/java/com/washuTechnologies/merced/intergrationtest/ui/AppViewModelTest.kt
@@ -7,6 +7,8 @@ import com.washuTechnologies.merced.util.StandardTestDispatcherRule
 import com.washuTechnologies.merced.util.MockDatasourceHelper
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.last
+import kotlinx.coroutines.flow.take
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
@@ -48,7 +50,7 @@ class AppViewModelTest {
             GetConnectivityStateUseCase(connectivityRepo)
         ).run {
             // When app state is emitted
-            val state = appState.first()
+            val state = appState.take(2).last()
 
             // Then the connectivity state is correct
             assertFalse(state.isInternetConnected)

--- a/app/src/test/java/com/washuTechnologies/merced/intergrationtest/ui/AppViewModelTest.kt
+++ b/app/src/test/java/com/washuTechnologies/merced/intergrationtest/ui/AppViewModelTest.kt
@@ -3,16 +3,21 @@ package com.washuTechnologies.merced.intergrationtest.ui
 import com.washuTechnologies.merced.data.connectivity.ConnectivityRepository
 import com.washuTechnologies.merced.domain.connectivity.GetConnectivityStateUseCase
 import com.washuTechnologies.merced.ui.AppViewModel
+import com.washuTechnologies.merced.util.StandardTestDispatcherRule
 import com.washuTechnologies.merced.util.MockDatasourceHelper
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
+import org.junit.Rule
 import org.junit.Test
 
 @OptIn(ExperimentalCoroutinesApi::class)
 class AppViewModelTest {
+
+    @get:Rule
+    val coroutineRule = StandardTestDispatcherRule()
 
     @Test
     fun `when connected the app state is correct`() = runTest {

--- a/app/src/test/java/com/washuTechnologies/merced/intergrationtest/ui/launchlist/LaunchListViewModelIntegrationTest.kt
+++ b/app/src/test/java/com/washuTechnologies/merced/intergrationtest/ui/launchlist/LaunchListViewModelIntegrationTest.kt
@@ -5,10 +5,9 @@ import com.washuTechnologies.merced.data.launches.datasources.LaunchesRemoteData
 import com.washuTechnologies.merced.ui.launchlist.LaunchListUiState
 import com.washuTechnologies.merced.ui.launchlist.LaunchListViewModel
 import com.washuTechnologies.merced.usecases.GetRocketListUseCase
-import com.washuTechnologies.merced.util.MockDatasourceHelper
-import com.washuTechnologies.merced.util.MockDatasourceHelper.mockLaunchesRemoteDatasource
 import com.washuTechnologies.merced.util.MockDatasourceHelper.mockConnectivity
 import com.washuTechnologies.merced.util.MockDatasourceHelper.mockLaunchesLocalSource
+import com.washuTechnologies.merced.util.MockDatasourceHelper.mockLaunchesRemoteDatasource
 import com.washuTechnologies.merced.util.RepositoryHelper
 import com.washuTechnologies.merced.util.SampleData
 import io.mockk.coEvery
@@ -27,9 +26,12 @@ class LaunchListViewModelIntegrationTest {
 
     @Test
     fun `when a launch list is requested then loading is first returned`() = runTest() {
+        val dispatcher = StandardTestDispatcher(testScheduler)
+
         LaunchListViewModel(
             GetRocketListUseCase(
-                RepositoryHelper.launchesRepository()
+                RepositoryHelper.launchesRepository(),
+                dispatcher
             ),
             StandardTestDispatcher(testScheduler)
         ).run {
@@ -40,6 +42,7 @@ class LaunchListViewModelIntegrationTest {
 
     @Test
     fun `given the api returns a launch list then it is displayed`() = runTest() {
+        val dispatcher = StandardTestDispatcher(testScheduler)
         val remoteDatasource = mockLaunchesRemoteDatasource(SampleData.launchList)
         val localDatasource = mockLaunchesLocalSource(emptyArray())
         val launchRepo = RepositoryHelper.launchesRepository(
@@ -49,8 +52,8 @@ class LaunchListViewModelIntegrationTest {
         // Given the remote datasource has results
         // and the cache is empty
         LaunchListViewModel(
-            GetRocketListUseCase(launchRepo),
-            StandardTestDispatcher(testScheduler)
+            GetRocketListUseCase(launchRepo, dispatcher),
+            dispatcher
         ).run {
             // When ui state is emitted
             val actual: LaunchListUiState = uiState.take(2).last()
@@ -65,6 +68,7 @@ class LaunchListViewModelIntegrationTest {
     @Test
     fun `given the internet is not connected then a cached list is returned`() =
         runTest() {
+            val dispatcher = StandardTestDispatcher(testScheduler)
             val localDatasource = mockLaunchesLocalSource(
                 SampleData.launchList
             )
@@ -78,8 +82,8 @@ class LaunchListViewModelIntegrationTest {
             // Given the local datasource has launch information
             // and the internet is not connected
             LaunchListViewModel(
-                GetRocketListUseCase(launchRepo),
-                StandardTestDispatcher(testScheduler)
+                GetRocketListUseCase(launchRepo, dispatcher),
+                dispatcher
             ).run {
                 // When ui state is emitted
                 val actual = uiState.take(2).last()
@@ -93,13 +97,14 @@ class LaunchListViewModelIntegrationTest {
 
     @Test
     fun `when a network error occurs a cached list is returned`() = runTest() {
+        val dispatcher = StandardTestDispatcher(testScheduler)
         val remoteDatasource = mockk<LaunchesRemoteDatasource> {
             coEvery { getRocketLaunchList() } answers {
                 throw NetworkErrorException()
             }
         }
         val localDatasource = mockLaunchesLocalSource(SampleData.launchList)
-        val repo = RepositoryHelper.launchesRepository(
+        val launchRepo = RepositoryHelper.launchesRepository(
             remoteDatasource = remoteDatasource,
             localDatasource = localDatasource,
             connectivityDatasource = mockConnectivity(true)
@@ -107,8 +112,8 @@ class LaunchListViewModelIntegrationTest {
 
         // Given there is no local list and the internet is  not connected
         LaunchListViewModel(
-            GetRocketListUseCase(repo),
-            StandardTestDispatcher(testScheduler)
+            GetRocketListUseCase(launchRepo, dispatcher),
+            dispatcher
         ).run {
             // When ui state is emitted
             val actual = uiState.take(2).last()
@@ -122,11 +127,12 @@ class LaunchListViewModelIntegrationTest {
 
     @Test
     fun `when the cache is out of date it is updated`() = runTest() {
+        val dispatcher = StandardTestDispatcher(testScheduler)
         val remoteDatasource = mockLaunchesRemoteDatasource(SampleData.launchList)
         val localDatasource = mockLaunchesLocalSource(
             SampleData.launchList.first()
         )
-        val repo = RepositoryHelper.launchesRepository(
+        val launchRepo = RepositoryHelper.launchesRepository(
             remoteDatasource = remoteDatasource,
             localDatasource = localDatasource,
             connectivityDatasource = mockConnectivity(true)
@@ -134,8 +140,8 @@ class LaunchListViewModelIntegrationTest {
 
         // Given there is cached data but the remote data source has an update
         LaunchListViewModel(
-            GetRocketListUseCase(repo),
-            StandardTestDispatcher(testScheduler)
+            GetRocketListUseCase(launchRepo, dispatcher),
+            dispatcher
         ).run {
             // When ui state is emitted
             val actual: LaunchListUiState = uiState.take(2).last()

--- a/app/src/test/java/com/washuTechnologies/merced/unittest/ui/launchlist/LaunchListViewModelUnitTest.kt
+++ b/app/src/test/java/com/washuTechnologies/merced/unittest/ui/launchlist/LaunchListViewModelUnitTest.kt
@@ -28,7 +28,7 @@ class LaunchListViewModelUnitTest {
         }
 
         LaunchListViewModel(
-            GetRocketListUseCase(mockRepository),
+            GetRocketListUseCase(mockRepository, StandardTestDispatcher(testScheduler)),
             StandardTestDispatcher(testScheduler)
         ).run {
             val actual: LaunchListUiState = uiState.take(2).last()
@@ -48,7 +48,7 @@ class LaunchListViewModelUnitTest {
         }
 
         LaunchListViewModel(
-            GetRocketListUseCase(mockRepository),
+            GetRocketListUseCase(mockRepository, StandardTestDispatcher(testScheduler)),
             StandardTestDispatcher(testScheduler)
         ).run {
             val actual: LaunchListUiState = uiState.take(2).last()

--- a/app/src/test/java/com/washuTechnologies/merced/util/MainCoroutineScopeRule.kt
+++ b/app/src/test/java/com/washuTechnologies/merced/util/MainCoroutineScopeRule.kt
@@ -1,0 +1,25 @@
+package com.washuTechnologies.merced.util
+
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.TestDispatcher
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.setMain
+import org.junit.rules.TestWatcher
+import org.junit.runner.Description
+
+@ExperimentalCoroutinesApi
+class StandardTestDispatcherRule(
+    private val dispatcher: TestDispatcher = StandardTestDispatcher()
+) : TestWatcher() {
+    override fun starting(description: Description) {
+        super.starting(description)
+        Dispatchers.setMain(dispatcher)
+    }
+
+    override fun finished(description: Description) {
+        super.finished(description)
+        Dispatchers.resetMain()
+    }
+}

--- a/app/src/test/java/com/washuTechnologies/merced/util/MockDatasourceHelper.kt
+++ b/app/src/test/java/com/washuTechnologies/merced/util/MockDatasourceHelper.kt
@@ -28,7 +28,7 @@ object MockDatasourceHelper {
 
     fun mockConnectivity(connectivityState: Flow<Boolean> = flow { emit(true) }) =
         mockk<ConnectivityDatasource> {
-            every { hasConnectivity } returns connectivityState
+            every { isInternetConnected } returns connectivityState
         }
 
     fun mockLaunchesLocalSource(launch: RocketLaunch) = mockLaunchesLocalSource(arrayOf(launch))

--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 buildscript {
     ext {
         nav_version = "2.5.1"
-        compose_version = '1.1.1'
+        compose_version = '1.2.1'
         material_version = '1.0.0-alpha07'
         mockk_version = '1.12.8'
         detekt_version = '1.20.0-RC1'


### PR DESCRIPTION
Show a message to the user when they're device is not connected to the internet informing them the displayed information may not be up to date. Additionally hides the launch image on the detail screen when it cannot be downloaded for the internet and no cached version is found.

![Screenshot_20220917_222424](https://user-images.githubusercontent.com/8459796/191101962-d3da0c1f-7480-40dd-8852-26319118033f.png)
![Screenshot_20220917_222525](https://user-images.githubusercontent.com/8459796/191101967-d1213b5d-2f86-49b9-89f2-23f5aaa1bfef.png)
![Screenshot_20220919_201940](https://user-images.githubusercontent.com/8459796/191101970-a49ee742-de26-4214-a297-0d19a4dc5af6.png)

